### PR TITLE
add basic flac vorbis support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 id3 = "1.14.0"
 thiserror = "1.0.63"
+metaflac = { git = "ssh://git@github.com/hungl6844/rust-metaflac.git" }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 id3 = "1.14.0"
 thiserror = "1.0.63"
-metaflac = { git = "ssh://git@github.com/hungl6844/rust-metaflac.git" }
+metaflac = { git = "https://github.com/hungl6844/rust-metaflac.git" }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,7 @@
 use crate::{Error, Result};
 use id3::frame::Picture as Id3Picture;
 use id3::frame::Timestamp as Id3Timestamp;
+use metaflac::block::Picture as FlacPicture;
 use std::str::FromStr;
 
 #[derive(Clone, Debug)]
@@ -25,6 +26,15 @@ impl From<Id3Picture> for Picture {
     }
 }
 
+impl From<FlacPicture> for Picture {
+    fn from(value: FlacPicture) -> Self {
+        Picture {
+            data: value.data,
+            mime_type: value.mime_type,
+        }
+    }
+}
+
 impl std::fmt::Display for Picture {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -36,7 +46,7 @@ impl std::fmt::Display for Picture {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Timestamp {
     pub year: i32,
     pub month: Option<u8>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod data;
 use data::*;
 use id3::Tag as Id3InternalTag;
 use id3::TagLike;
+use metaflac::Tag as FlacInternalTag;
 use std::path::Path;
 use thiserror::Error;
 
@@ -16,6 +17,8 @@ pub enum Error {
     UnsupportedFormat,
     #[error("{0}")]
     Id3Error(#[from] id3::Error),
+    #[error("{0}")]
+    FlacError(#[from] metaflac::Error),
     #[error("Unable to parse timestamp from string")]
     TimestampParseError,
 }
@@ -25,6 +28,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Tag {
     Id3Tag { inner: Id3InternalTag },
+    VorbisFlacTag { inner: FlacInternalTag },
 }
 
 impl Tag {
@@ -40,13 +44,18 @@ impl Tag {
                 let inner = Id3InternalTag::read_from_path(path)?;
                 Ok(Self::Id3Tag { inner })
             }
+            "flac" => {
+                let inner = FlacInternalTag::read_from_path(path)?;
+                Ok(Self::VorbisFlacTag { inner })
+            }
             _ => Err(Error::UnsupportedFormat),
         }
     }
 
-    pub fn write_to_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+    pub fn write_to_path<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
         match self {
             Self::Id3Tag { inner } => inner.write_to_path(path, id3::Version::Id3v24)?,
+            Self::VorbisFlacTag { inner } => inner.write_to_path(path)?,
         };
         Ok(())
     }
@@ -63,6 +72,20 @@ impl Tag {
                 Some(Album {
                     title: inner.album()?.into(),
                     artist: inner.album_artist()?.into(),
+                    cover,
+                })
+            }
+            Self::VorbisFlacTag { inner } => {
+                let cover = inner
+                    .pictures()
+                    .find(|&pic| {
+                        matches!(pic.picture_type, metaflac::block::PictureType::CoverFront)
+                    })
+                    .map(|pic| Picture::from(pic.clone()));
+
+                Some(Album {
+                    title: inner.get_vorbis("ALBUM")?.next()?.to_string(),
+                    artist: inner.get_vorbis("ALBUM_ARTIST")?.next()?.to_string(),
                     cover,
                 })
             }
@@ -84,6 +107,21 @@ impl Tag {
                     });
                 }
             }
+            Self::VorbisFlacTag { inner } => {
+                inner.set_vorbis("ALBUM", vec![album.title]);
+                inner.set_vorbis("ALBUMARTIST", vec![&album.artist]);
+                inner.set_vorbis("ALBUM ARTIST", vec![&album.artist]);
+                inner.set_vorbis("ALBUM_ARTIST", vec![&album.artist]);
+
+                if let Some(picture) = album.cover {
+                    inner.remove_picture_type(metaflac::block::PictureType::CoverFront);
+                    inner.add_picture(
+                        picture.mime_type,
+                        metaflac::block::PictureType::CoverFront,
+                        picture.data,
+                    );
+                }
+            }
         }
     }
 
@@ -91,25 +129,35 @@ impl Tag {
     pub fn title(&self) -> Option<&str> {
         match self {
             Self::Id3Tag { inner } => inner.title(),
+            Self::VorbisFlacTag { inner } => inner.get_vorbis("TITLE")?.next(),
         }
     }
 
     pub fn set_title(&mut self, title: &str) {
         match self {
             Self::Id3Tag { inner } => inner.set_title(title),
+            Self::VorbisFlacTag { inner } => inner.set_vorbis("TITLE", vec![title]),
         }
     }
 
     #[must_use]
-    pub fn artist(&self) -> Option<&str> {
+    pub fn artist(&self) -> Option<String> {
         match self {
-            Self::Id3Tag { inner } => inner.artist(),
+            Self::Id3Tag { inner } => inner.artist().map(std::string::ToString::to_string),
+            Self::VorbisFlacTag { inner } => Some(
+                inner
+                    .get_vorbis("ARTIST")?
+                    .collect::<Vec<&str>>()
+                    .join("; "),
+            )
+            .filter(|s| !s.is_empty()),
         }
     }
 
     pub fn set_artist(&mut self, artist: &str) {
         match self {
             Self::Id3Tag { inner } => inner.set_artist(artist),
+            Self::VorbisFlacTag { inner } => inner.set_vorbis("ARTIST", vec![artist]),
         }
     }
 
@@ -117,12 +165,35 @@ impl Tag {
     pub fn date(&self) -> Option<Timestamp> {
         match self {
             Self::Id3Tag { inner } => inner.date_released().map(std::convert::Into::into),
+            Self::VorbisFlacTag { inner } => {
+                inner
+                    .get_vorbis("DATE")?
+                    .next()
+                    .map(|s: &str| -> Option<Timestamp> {
+                        let date = s.split('-').collect::<Vec<&str>>();
+                        Some(Timestamp {
+                            year: date[0].parse().ok()?,
+                            month: date[1].parse().ok(),
+                            day: date[2].parse().ok(),
+                            ..Default::default()
+                        })
+                    })?
+            }
         }
     }
 
     pub fn set_date(&mut self, timestamp: Timestamp) {
         match self {
             Self::Id3Tag { inner } => inner.set_date_released(timestamp.into()),
+            Self::VorbisFlacTag { inner } => inner.set_vorbis(
+                "DATE",
+                vec![format!(
+                    "{:04}-{:02}-{:02}",
+                    timestamp.year,
+                    timestamp.month.unwrap_or(0),
+                    timestamp.day.unwrap_or(0)
+                )],
+            ),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use id3::Tag as Id3InternalTag;
 use id3::TagLike;
 use metaflac::Tag as FlacInternalTag;
 use std::path::Path;
+use std::str::FromStr;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -165,20 +166,10 @@ impl Tag {
     pub fn date(&self) -> Option<Timestamp> {
         match self {
             Self::Id3Tag { inner } => inner.date_released().map(std::convert::Into::into),
-            Self::VorbisFlacTag { inner } => {
-                inner
-                    .get_vorbis("DATE")?
-                    .next()
-                    .map(|s: &str| -> Option<Timestamp> {
-                        let date = s.split('-').collect::<Vec<&str>>();
-                        Some(Timestamp {
-                            year: date[0].parse().ok()?,
-                            month: date[1].parse().ok(),
-                            day: date[2].parse().ok(),
-                            ..Default::default()
-                        })
-                    })?
-            }
+            Self::VorbisFlacTag { inner } => inner
+                .get_vorbis("DATE")?
+                .next()
+                .map(|s| -> Option<Timestamp> { Timestamp::from_str(s).ok() })?,
         }
     }
 


### PR DESCRIPTION
our main problem lies in the way flac handles comments: flac allows for key-value pairs in the form of vorbis comments. However, one key can correspond to multiple values, given that `metaflac` returns an `Iterator` on the `get_vorbis` method. This is non-consequential in most cases, but if a flac file contains more than one `ARTIST` value, `multitag` needs to turn these values into a string. Right now, I have a delimiter (`; `), but because music metadata standards are pretty messy, there are many accepted delimiters (` / `, `, `, etc.), and the end user may not appreciate my usage of the semicolon.