### PR TITLE
Fix album author not being detected in .opus files modified using mp3tag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,9 +212,14 @@ impl Tag {
                     .get_picture_type(opusmeta::picture::PictureType::CoverFront)
                     .map(Picture::from);
 
+                let artist = inner
+                    .get_one("ALBUM_ARTIST".into())
+                    .or_else(|| inner.get_one("ALBUMARTIST".into()))
+                    .map(Into::into);
+
                 Some(Album {
                     title: inner.get_one("ALBUM".into()).map(Into::into),
-                    artist: inner.get_one("ALBUM_ARTIST".into()).map(Into::into),
+                    artist,
                     cover,
                 })
             }


### PR DESCRIPTION
mp3tag writes the album author as `ALBUMARTIST`. The .opus parser wasn't handling this case, so I've updated it.