### PR TITLE
fix `get_album_info` for oggmeta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+/.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "master"
-    ]
-}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "2"
 mp4ameta = "0.13.0"
 metaflac = "0.2.8"
 opusmeta = "2.0.0"
-oggmeta = "1.2.3"
+oggmeta = "1.2.4"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 id3 = "1.14.0"
 mp4ameta = "0.13.0"
 metaflac = "0.2.8"
-oggmeta = "1.2.4"
+oggmeta = "1.3.0"
 opusmeta = "3.0.0"
 
 [lints.clippy]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// An object containing tags of one of the supported formats.
+#[derive(Debug)]
 pub enum Tag {
     Id3Tag { inner: Id3InternalTag },
     VorbisFlacTag { inner: FlacInternalTag },
@@ -350,13 +351,13 @@ impl Tag {
                 Some(Album {
                     title: inner
                         .comments
-                        .get("album")?
-                        .first()
+                        .get("ALBUM")
+                        .and_then(|v| v.first())
                         .map(std::convert::Into::into),
                     artist: inner
                         .comments
-                        .get("album_artist")?
-                        .first()
+                        .get("ALBUM_ARTIST")
+                        .and_then(|v| v.first())
                         .map(std::convert::Into::into),
                     cover,
                 })
@@ -440,12 +441,12 @@ impl Tag {
             }
             Self::OggTag { inner } => {
                 if let Some(title) = album.title {
-                    inner.comments.insert("album".into(), vec![title]);
+                    inner.comments.insert("ALBUM".into(), vec![title]);
                 }
                 if let Some(album_artist) = album.artist {
                     inner
                         .comments
-                        .insert("album_artist".into(), vec![album_artist]);
+                        .insert("ALBUM_ARTIST".into(), vec![album_artist]);
                 }
                 if let Some(picture) = album.cover {
                     // Try to decode the image to obtain width/height and color depth


### PR DESCRIPTION
title:
stops `get_album_info` from returning None if either `ALBUM` or `ALBUM_ARTIST` don't exist in an ogg file, as well as improving consistency in using uppercase tags for oggmeta

in the future, fetching the tags in oggmeta will be improved to be case-insensitive (and I'll create a new pr at that time)